### PR TITLE
Fix/criteria constraint change unit display

### DIFF
--- a/src/app/modules/querybuilder/components/querybuilder-editor/edit/edit-value-filter/edit-value-filter.component.html
+++ b/src/app/modules/querybuilder/components/querybuilder-editor/edit/edit-value-filter/edit-value-filter.component.html
@@ -92,10 +92,10 @@
             [max]="filter?.max"
           />
           <mat-hint *ngIf="valueTooSmall(filter.minValue)">{{
-            'QUERYBUILDER.HINT.MINIMUM_EXCEEDED' | translate: { min: filter.min }
+            'QUERYBUILDER.HINT.MINIMUM_EXCEEDED' | translate : { min: filter.min }
           }}</mat-hint>
           <mat-hint *ngIf="valueTooLarge(filter.minValue)">{{
-            'QUERYBUILDER.HINT.MAXIMUM_EXCEEDED' | translate: { max: filter.max }
+            'QUERYBUILDER.HINT.MAXIMUM_EXCEEDED' | translate : { max: filter.max }
           }}</mat-hint>
         </mat-form-field>
         <span *ngIf="filter.type === OperatorOptions.QUANTITY_RANGE">{{
@@ -117,10 +117,10 @@
             [precision]="filter.precision"
           />
           <mat-hint *ngIf="valueTooSmall(filter.maxValue)">{{
-            'QUERYBUILDER.HINT.MINIMUM_EXCEEDED' | translate: { min: filter.min }
+            'QUERYBUILDER.HINT.MINIMUM_EXCEEDED' | translate : { min: filter.min }
           }}</mat-hint>
           <mat-hint *ngIf="valueTooLarge(filter.maxValue)">{{
-            'QUERYBUILDER.HINT.MAXIMUM_EXCEEDED' | translate: { max: filter.max }
+            'QUERYBUILDER.HINT.MAXIMUM_EXCEEDED' | translate : { max: filter.max }
           }}</mat-hint>
         </mat-form-field>
         <mat-form-field
@@ -139,16 +139,17 @@
             [precision]="filter.precision"
           />
           <mat-hint *ngIf="valueTooSmall(filter.value)">{{
-            'QUERYBUILDER.HINT.MINIMUM_EXCEEDED' | translate: { min: filter.min }
+            'QUERYBUILDER.HINT.MINIMUM_EXCEEDED' | translate : { min: filter.min }
           }}</mat-hint>
           <mat-hint *ngIf="valueTooLarge(filter.value)">{{
-            'QUERYBUILDER.HINT.MAXIMUM_EXCEEDED' | translate: { max: filter.max }
+            'QUERYBUILDER.HINT.MAXIMUM_EXCEEDED' | translate : { max: filter.max }
           }}</mat-hint>
         </mat-form-field>
         <mat-form-field appearance="outline" *ngIf="filter?.unit" class="unit-part">
           <mat-label>{{ 'QUERYBUILDER.EDIT.UNIT' | translate }}</mat-label>
           <mat-select
-            *ngIf="filterType === 'value'"
+            [disabled]="false"
+            *ngIf="filterType === 'value' && !disableSelect()"
             [(value)]="filter.unit"
             [compareWith]="compareFunction"
           >
@@ -156,6 +157,13 @@
               {{ unit.display }}
             </mat-option>
           </mat-select>
+          <input
+            matInput
+            *ngIf="filterType === 'value' && disableSelect()"
+            [value]="filter.unit.display"
+            placeholder="filter.unit.display"
+            disabled
+          />
           <mat-select
             *ngIf="filterType === 'attribute'"
             [(value)]="filter.unit"

--- a/src/app/modules/querybuilder/components/querybuilder-editor/edit/edit-value-filter/edit-value-filter.component.ts
+++ b/src/app/modules/querybuilder/components/querybuilder-editor/edit/edit-value-filter/edit-value-filter.component.ts
@@ -7,6 +7,7 @@ import {
 } from '../../../../model/api/query/valueFilter';
 import { TerminologyCode } from '../../../../model/api/terminology/terminology';
 import { ObjectHelper } from '../../../../controller/ObjectHelper';
+import { FormControl } from '@angular/forms';
 
 @Component({
   selector: 'num-edit-value-definition',
@@ -196,5 +197,9 @@ export class EditValueFilterComponent implements OnInit, AfterViewInit {
   // values come from the for-iteration (unit), option is the selected one ([(value)]="filter.unit")
   compareFunction(values, option): boolean {
     return values.code === option.code;
+  }
+
+  disableSelect() {
+    return this.filter.valueDefinition?.allowedUnits.length > 1 ? false : true;
   }
 }


### PR DESCRIPTION
If the array called "allowedUnits" contains only one item, the user interface will show a disabled input field with the display value of the allowed unit. Otherwise, a dropdown menu will be displayed with multiple options.

To provide clarity, here is an example of how the "allowedUnits" array appears:

 "allowedUnits": [
                                    {
                                        "code": "10*3/uL",
                                        "display": "10*3/uL"
                                    }
                                ],