### PR TITLE
Release v6.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## v6.4.0 (2025-11-24)
+
+### Changed
+* Removed unused and outdated configuration entries; Data Portal settings are now retrieved from the backend settings endpoint during application initialization. [#432](https://github.com/medizininformatik-initiative/feasibility-gui/issues/432)
+* CRTDL display objects are now loaded from the backend at startup. [#455](https://github.com/medizininformatik-initiative/feasibility-gui/issues/455)
+* Improved display of terminology titles. [#465](https://github.com/medizininformatik-initiative/feasibility-gui/issues/465)
+* Renamed the URL of the profile editing page to use the “feature” segment. [#467](https://github.com/medizininformatik-initiative/feasibility-gui/issues/467)
+
+### Features
+* Implemented auto-save functionality in the data selection editor; profile changes are now saved automatically.
+  [#468](https://github.com/medizininformatik-initiative/feasibility-gui/issues/468)
+* Added a selectable boolean to criteria-relative data to prevent adding elements to the cohort when not allowed.
+  [#482](https://github.com/medizininformatik-initiative/feasibility-gui/issues/482)
+* Outsourced the action bar from the data-selection display component.
+  [#479](https://github.com/medizininformatik-initiative/feasibility-gui/issues/479)
+
+### Fixed
+* Fixed UI crashes occurring when linking a reference in the data selection.
+  [#478](https://github.com/medizininformatik-initiative/feasibility-gui/issues/478)
+* Prevented flickering of route animations.
+  [#483](https://github.com/medizininformatik-initiative/feasibility-gui/issues/483)
+* Prevented accidental deletion of selected concepts in the criterion editor during scrolling and enabled automatic addition to stage.
+  [#486](https://github.com/medizininformatik-initiative/feasibility-gui/issues/486)
+* Ensured that the criterion filter is loaded correctly when not set in CRTDL by using the value-attribute definition.
+  [#488](https://github.com/medizininformatik-initiative/feasibility-gui/issues/488)
+
+
 ## v6.3.7 (2025-10-08)
 
 ### Features

--- a/docker/deploy-config.json
+++ b/docker/deploy-config.json
@@ -1,59 +1,11 @@
 {
-  "env": {
-    "name": "dev"
-  },
-  "api": {
-    "baseUrl": "/api"
-  },
-  "uiBackendApi": {
-    "baseUrl": "http://localhost:8090/api/v5"
-  },
-  "auth": {
-    "baseUrl": "http://localhost:8080/auth",
-    "realm": "codex-develop",
-    "clientId": "feasibility-gui",
-    "roles": ["FEASIBILITY_USER"]
-  },
-  "legal": {
-    "version": "6.3.7",
-    "copyrightYear": "2025",
-    "copyrightOwner": "FDPG+ Team",
-    "email": "info@forschen-fuer-gesundheit.de"
-  },
-  "features": {
-    "v2": {
-      "multiplevaluedefinitions": true,
-      "multiplegroups": false,
-      "dependentgroups": true,
-      "timerestriction": true
-    },
-    "extra": {
-      "displayvaluefiltericon": false,
-      "showoptionspage": true,
-      "showdataselectionpage": false,
-      "optionpageroles": ["FEASIBILITY_USER"],
-      "displayInfoMessage": true,
-      "displayUpdateInfo": true
-    }
-  },
-  "options": {
-    "sendsqcontexttobackend": true,
-    "pollingtimeinseconds": 10,
-    "pollingintervallinseconds": 10,
-    "lowerboundarypatientresult": 10,
-    "lowerboundarylocationresult": 1,
-    "dsePatientProfileUrl": "https://www.medizininformatik-initiative.de/fhir/core/modul-person/StructureDefinition/PatientPseudonymisiert"
-
-  },
-  "mock": {
-    "terminology": false,
-    "query": false,
-    "result": false,
-    "loadnsave": false
-  },
+  "authBaseUrl": "http://localhost:8080/auth",
+  "authClientId": "feasibility-gui",
+  "authRealm": "codex-develop",
+  "backendBaseUrl": "http://localhost:8090",
+  "copyrightOwner": "FDPG+ Team",
+  "copyrightYear": "2025",
+  "email": "info@forschen-fuer-gesundheit.de",
   "stylesheet": "FDPGTheme",
-  "fhirport": "8082",
-  "dataset": "codex",
-  "queryVersion": "v2",
-  "proposalPortalLink": "https://antrag.dev.forschen-fuer-gesundheit.de/"
+  "version": "6.4.0"
 }

--- a/docker/lang/de.json
+++ b/docker/lang/de.json
@@ -1,15 +1,15 @@
 {
   "APPLAYOUT": {
+    "HEADER": {
+      "ABOUT": "Über das Portal",
+      "LOGOUT": "Abmelden",
+      "PROPOSAL_PORTAL": "Antragsportal"
+    },
     "SIDENAV": {
       "LABEL": "Seitennavigation"
     },
     "TOGGLE": {
       "LABEL": "Seitennavigation umschalten"
-    },
-    "HEADER": {
-      "PROPOSAL_PORTAL": "Antragsportal",
-      "ABOUT": "Über das Portal",
-      "LOGOUT": "Abmelden"
     }
   },
   "DATAQUERY": {
@@ -106,6 +106,10 @@
           "ADD": "Neues Merkmal hinzufügen",
           "INFO": "Klicken Sie auf neues Merkmal hinzufügen, um ein neues Merkmal zu erstellen"
         },
+        "SNACKBAR": {
+          "SAVED": "Profil erfolgreich gespeichert",
+          "SAVING_ERROR": "Fehler beim Speichern des Profils"
+        },
         "TAB_LABEL": {
           "FIELD": "Felder",
           "FILTER": "Filter",
@@ -121,14 +125,14 @@
   },
   "ERROR": {
     "404": "Standort wurde nicht gefunden",
+    "DSE-10001": "Ein ausgewähltes Feld konnte nicht geladen werden",
     "FEAS-10001": "Ihr Account wurde wegen zu vieler Abfragen gesperrt, bitte wenden Sie sich an info@forschen-fuer-gesundheit.de",
     "FEAS-10002": "Sie haben zu viele Abfragen gestellt, bitte warten Sie und probieren Sie es erneut.",
     "FEAS-10003": "Sie haben zu viele Abfragen gestellt, bitte warten Sie und probieren Sie es erneut.",
     "FEAS-10004": "Die Ergebnismenge ist zu klein → Ergebnis wird nicht angezeigt.",
     "FEAS-10005": "Die Anzahl der Standorte, die geantwortet haben, ist zu klein → Detailergebnis wird nicht angezeigt.",
     "FEAS-10006": "Sie haben zu viele Kohorten gespeichert, bitte löschen Sie Kohortenselektionen, bevor Sie weitere speichern.",
-    "VAL-20001": "Die Kombination aus Kontext und Termcode(s) wurde nicht gefunden.",
-    "DSE-10001": "Ein ausgewähltes Feld konnte nicht geladen werden"
+    "VAL-20001": "Die Kombination aus Kontext und Termcode(s) wurde nicht gefunden."
   },
   "FEASIBILITY": {
     "EDITOR": {
@@ -249,7 +253,12 @@
       "HEADER_INFO": "Definieren Sie Ihre Kohorte anhand von Kriterien, die Sie über das Suchfeld auswählen können. Für gezieltes Suchen können Sie auf bestimmte Terminologien (z. B. ICD-10, LOINC, OPS) oder KDS-Module einschränken. Sie können die Kohortenselektion direkt verwenden, um die Zahl von Patientinnen und Patienten deutschlandweit abzuschätzen.",
       "LABEL": "Code oder Suchbegriff eingeben",
       "SEARCHBAR": "Suchen nach Begriff oder Terminologiecode",
-      "SEARCH_BUTTON": "Suchen"
+      "SEARCH_BUTTON": "Suchen",
+      "SNACKBAR": {
+        "ADDED_TO_COHORT": "Kriterien wurden zur Kohortenselektion hinzugefügt",
+        "ADDED_TO_STAGE": "Kriterium wurde ausgewählt",
+        "REMOVED_FROM_STAGE": "Kriterium wurde entfernt"
+      }
     }
   },
   "LANGUAGE": {
@@ -358,18 +367,21 @@
     },
     "TABLE": {
       "AVAILABILITY": "Verfügbarkeit",
-      "SELECT_CHECKBOX": "Kriterium auswählen",
       "CONTEXT": "Kontext",
       "DISPLAY": "Anzeige",
+      "ICON": "Verwandte Kriterien anzeigen",
       "NAME": "Name",
       "PATIENT_COUNT": "Anzahl der Patienten",
+      "SELECT_CHECKBOX": "Kriterium auswählen",
       "SITE": "Standort",
       "TERMCODE": "Termcode",
-      "TERMINOLOGY_CODE": "Terminologie",
-      "ICON": "Verwandte Kriterien anzeigen"
+      "TERMINOLOGY_CODE": "Terminologie"
     }
   },
   "SHARED_FILTER": {
+    "CONCEPT_FILTER": {
+      "SEARCH_PLACEHOLDER": "Begriff oder Termcode eingeben"
+    },
     "TIMERESTRICTION": {
       "AFTER": "nach",
       "AT": "am",

--- a/docker/lang/en.json
+++ b/docker/lang/en.json
@@ -1,15 +1,15 @@
 {
   "APPLAYOUT": {
+    "HEADER": {
+      "ABOUT": "About the Portal",
+      "LOGOUT": "Log Out",
+      "PROPOSAL_PORTAL": "Proposal Portal"
+    },
     "SIDENAV": {
       "LABEL": "Side navigation"
     },
     "TOGGLE": {
       "LABEL": "Toggle side navigation"
-    },
-    "HEADER": {
-      "PROPOSAL_PORTAL": "Proposal Portal",
-      "ABOUT": "About the Portal",
-      "LOGOUT": "Log Out"
     }
   },
   "DATAQUERY": {
@@ -106,6 +106,10 @@
           "ADD": "Add new reference",
           "INFO": "Click on 'Add new reference' to create a new reference"
         },
+        "SNACKBAR": {
+          "SAVED": "Profile saved successfully",
+          "SAVING_ERROR": "Error saving profile"
+        },
         "TAB_LABEL": {
           "FIELD": "Fields",
           "FILTER": "Filter",
@@ -121,14 +125,14 @@
   },
   "ERROR": {
     "404": "Location not found",
+    "DSE-10001": "A selected field could not be loaded",
     "FEAS-10001": "Your account has been locked due to too many queries. Please contact info@research-for-health.de",
     "FEAS-10002": "You have made too many queries. Please wait and try again.",
     "FEAS-10003": "You have made too many queries. Please wait and try again.",
     "FEAS-10004": "The result set is too small; results will not be displayed.",
     "FEAS-10005": "The number of responding locations is too small; detailed results will not be displayed.",
     "FEAS-10006": "You have saved too many cohorts. Please delete some cohort selections before saving more.",
-    "VAL-20001": "The combination of context and term code(s) was not found.",
-    "DSE-10001": "A selected field could not be loaded"
+    "VAL-20001": "The combination of context and term code(s) was not found."
   },
   "FEASIBILITY": {
     "EDITOR": {
@@ -249,7 +253,12 @@
       "HEADER_INFO": "Define your cohort based on criteria selectable via the search field. For targeted searches, restrict by terminology (e.g., ICD10, LOINC, OPS) or CDS modules. Use the cohort selection to estimate patient counts nationwide.",
       "LABEL": "Enter code or search term",
       "SEARCHBAR": "Search for term or terminology code",
-      "SEARCH_BUTTON": "Search"
+      "SEARCH_BUTTON": "Search",
+      "SNACKBAR": {
+        "ADDED_TO_COHORT": "Criteria added to cohort selection",
+        "ADDED_TO_STAGE": "Criterion {{criterium}} was selected ",
+        "REMOVED_FROM_STAGE": "Criterion {{criterium}} was removed"
+      }
     }
   },
   "LANGUAGE": {
@@ -358,18 +367,21 @@
     },
     "TABLE": {
       "AVAILABILITY": "Availability",
-      "SELECT_CHECKBOX": "Select Criteria",
       "CONTEXT": "Context",
       "DISPLAY": "Display",
+      "ICON": "Show related criteria",
       "NAME": "Name",
       "PATIENT_COUNT": "Number of patients",
+      "SELECT_CHECKBOX": "Select Criteria",
       "SITE": "Location",
       "TERMCODE": "Term code",
-      "TERMINOLOGY_CODE": "Terminology",
-      "ICON": "Show related criteria"
+      "TERMINOLOGY_CODE": "Terminology"
     }
   },
   "SHARED_FILTER": {
+    "CONCEPT_FILTER": {
+      "SEARCH_PLACEHOLDER": "Enter concept or term code"
+    },
     "TIMERESTRICTION": {
       "AFTER": "after",
       "AT": "at",

--- a/src/assets/config/config.dev.json
+++ b/src/assets/config/config.dev.json
@@ -7,5 +7,5 @@
   "copyrightYear": "2025",
   "email": "info@forschen-fuer-gesundheit.de",
   "stylesheet": "FDPGTheme",
-  "version": "6.3.7"
+  "version": "6.4.0"
 }


### PR DESCRIPTION
### Changed
* Removed unused and outdated configuration entries; Data Portal settings are now retrieved from the backend settings endpoint during application initialization. [#432](https://github.com/medizininformatik-initiative/feasibility-gui/issues/432)
* CRTDL display objects are now loaded from the backend at startup. [#455](https://github.com/medizininformatik-initiative/feasibility-gui/issues/455)
* Improved display of terminology titles. [#465](https://github.com/medizininformatik-initiative/feasibility-gui/issues/465)
* Renamed the URL of the profile editing page to use the “feature” segment. [#467](https://github.com/medizininformatik-initiative/feasibility-gui/issues/467)

### Features
* Implemented auto-save functionality in the data selection editor; profile changes are now saved automatically.  [#468](https://github.com/medizininformatik-initiative/feasibility-gui/issues/468)
* Added a selectable boolean to criteria-relative data to prevent adding elements to the cohort when not allowed.  [#482](https://github.com/medizininformatik-initiative/feasibility-gui/issues/482)
* Outsourced the action bar from the data-selection display component.  [#479](https://github.com/medizininformatik-initiative/feasibility-gui/issues/479)

### Fixed
* Fixed UI crashes occurring when linking a reference in the data selection. [#478](https://github.com/medizininformatik-initiative/feasibility-gui/issues/478)
* Prevented flickering of route animations.  [#483](https://github.com/medizininformatik-initiative/feasibility-gui/issues/483)
* Prevented accidental deletion of selected concepts in the criterion editor during scrolling and enabled automatic addition to stage.  [#486](https://github.com/medizininformatik-initiative/feasibility-gui/issues/486)
* Ensured that the criterion filter is loaded correctly when not set in CRTDL by using the value-attribute definition.  [#488](https://github.com/medizininformatik-initiative/feasibility-gui/issues/488)