### PR TITLE
Release v6.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v6.6.0 (2025-02-05)
+
+### Features
+* Added a validation endpoint for CRTDLs to ensure only valid CRTDL files can be uploaded and used in the application. [#409](https://github.com/medizininformatik-initiative/dataportal-ui/issues/409)
+* Implemented a reusable modal to display validation errors, including support for reopening and an extended data model. [#507](https://github.com/medizininformatik-initiative/dataportal-ui/issues/507)
+
+### Changes
+* Removed support for uploading CCDL files, as this feature is no longer supported. [#320](https://github.com/medizininformatik-initiative/dataportal-ui/issues/320), [#471](https://github.com/medizininformatik-initiative/dataportal-ui/issues/471)
+* Introduced a global `DataportalErrorHandler` to capture and display application-wide errors, replacing Angular’s default `ErrorHandler`. [#433](https://github.com/medizininformatik-initiative/dataportal-ui/issues/433)
+* Refactored the HTTP interceptor to centralize error handling via the new `DataportalErrorHandler`. [#428](https://github.com/medizininformatik-initiative/dataportal-ui/issues/428)
+
+### Fixed
+* Recommended references on loaded CRTDL will not be set [#512](https://github.com/medizininformatik-initiative/dataportal-ui/issues/512)
+
 ## v6.5.0 (2025-12-10)
 
 ### Features

--- a/docker/deploy-config.json
+++ b/docker/deploy-config.json
@@ -7,5 +7,5 @@
   "copyrightYear": "2025",
   "email": "info@forschen-fuer-gesundheit.de",
   "stylesheet": "FDPGTheme",
-  "version": "6.5.0"
+  "version": "6.6.0"
 }

--- a/src/assets/config/config.dev.json
+++ b/src/assets/config/config.dev.json
@@ -7,5 +7,5 @@
   "copyrightYear": "2025",
   "email": "info@forschen-fuer-gesundheit.de",
   "stylesheet": "FDPGTheme",
-  "version": "6.5.0"
+  "version": "6.6.0"
 }


### PR DESCRIPTION
### Features
* Added a validation endpoint for CRTDLs to ensure only valid CRTDL files can be uploaded and used in the application. [#409](https://github.com/medizininformatik-initiative/dataportal-ui/issues/409)
* Implemented a reusable modal to display validation errors, including support for reopening and an extended data model. [#507](https://github.com/medizininformatik-initiative/dataportal-ui/issues/507)

### Changes
* Removed support for uploading CCDL files, as this feature is no longer supported. [#320](https://github.com/medizininformatik-initiative/dataportal-ui/issues/320), [#471](https://github.com/medizininformatik-initiative/dataportal-ui/issues/471)
* Introduced a global `DataportalErrorHandler` to capture and display application-wide errors, replacing Angular’s default `ErrorHandler`. [#433](https://github.com/medizininformatik-initiative/dataportal-ui/issues/433)
* Refactored the HTTP interceptor to centralize error handling via the new `DataportalErrorHandler`. [#428](https://github.com/medizininformatik-initiative/dataportal-ui/issues/428)

### Fixed
* Recommended references on loaded CRTDL will not be set [#512](https://github.com/medizininformatik-initiative/dataportal-ui/issues/512)
